### PR TITLE
Load collada files

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -22,7 +22,7 @@
 bl_info = {
     "name": "Mixamo Converter",
     "author": "Enzio Probst",
-    "version": (1, 0, 4),
+    "version": (1, 0, 5),
     "blender": (2, 7, 8),
     "location": "3D View > Tool Shelve > Mixamo Tab",
     "description": ("Script to bake Root motion for Mixamo Animations"),


### PR DESCRIPTION
This PR allows mixamo_converter to load DAE file and store FBX.
It can be used as workaround for broken FBX and for the issue #11.
Still looking for a way to fix #11 btw...
