### PR TITLE
Bones can be renamed to metch unreal skeleton. UI has been polished…

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@ is a Blender Plugin that Converts Mixamo animations to work in Unreal Engine 4 w
 Blender 2.78 or newer needed to work
 
 ### It can
-* convert single animations if they are previously imported by the user
-* Batch convert all FBX files from a folder to a new location
+* convert single animations (FBX or Collada) if they are previously imported by the user
+* Batch convert all input FBX and Collada files from a folder to a new location
+* Renames the bones in the skeleton to match the maniquine unreal skeleton
 
 ## Installation
 * first you have to get blender from https://www.blender.org/download/
@@ -42,6 +43,15 @@ Here you can specify a custom HipName if your Rig doesn't come from Mixamo. It w
 
 #### Option [Remove Namespace]
 If enabled, removes all namespaces, leaving you with only the object/bone bare names.
+This option is not compatible with "Use Unreal Engine bone names" option.
+To convert the bones of the armature in the scene select the armature and press the play button.
+Check this option to enable it for batch conversions.
+
+#### Option [Use Unreal Engine bone names]
+If enabled, renames all bones in the armature to match the unreal engine maniquine skeleton. If a bone doesn't match a warning is printed and the name becomes the original one but without the 'mixamo' namespace (as Remove Namespace does).
+This option is not compatible with "Remove Namespace" option.
+To convert the bones of the armature in the scene select the armature and press the play button.
+Check this option to enable it for batch conversions.
 
 #### Option [Fix Bind]
 If your source files only contain a rig without a mesh, adds a dummy mesh and binds it to the armature. Otherwise the bindpose will not be saved properly.

--- a/__init__.py
+++ b/__init__.py
@@ -2,7 +2,7 @@
 
 '''
     Copyright (C) 2017  Enzio Probst
-  
+
     Created by Enzio Probst
 
     This program is free software: you can redistribute it and/or modify
@@ -22,7 +22,7 @@
 bl_info = {
     "name": "Mixamo Converter",
     "author": "Enzio Probst",
-    "version": (1, 0, 5),
+    "version": (1, 0, 6),
     "blender": (2, 7, 8),
     "location": "3D View > Tool Shelve > Mixamo Tab",
     "description": ("Script to bake Root motion for Mixamo Animations"),
@@ -38,218 +38,246 @@ from . import mixamoconv
 class MixamoPropertyGroup(bpy.types.PropertyGroup):
     '''Property container for options and paths of mixamo Converter'''
     advanced = bpy.props.BoolProperty(
-                    name="Advanced Options",
-                    description="Display advanced options",
-                    default=False)
+        name="Advanced Options",
+        description="Display advanced options",
+        default=False)
     experimental = bpy.props.BoolProperty(
-                    name="Experimental Options",
-                    description="Experimental Options (use with caution, dirty workarounds)",
-                    default=False)
-    
+        name="Experimental Options",
+        description="Experimental Options (use with caution, dirty workarounds)",
+        default=False)
+
     use_x = bpy.props.BoolProperty(
-                    name="Use X",
-                    description="If enabled, Horizontal motion is transfered to RootBone",
-                    default=True)
+        name="Use X",
+        description="If enabled, Horizontal motion is transfered to RootBone",
+        default=True)
     use_y = bpy.props.BoolProperty(
-                    name="Use Y",
-                    description="If enabled, Horizontal motion is transfered to RootBone",
-                    default=True)
+        name="Use Y",
+        description="If enabled, Horizontal motion is transfered to RootBone",
+        default=True)
     use_z = bpy.props.BoolProperty(
-                    name="Use Z",
-                    description="If enabled, vertical motion is transfered to RootBone",
-                    default=True)
+        name="Use Z",
+        description="If enabled, vertical motion is transfered to RootBone",
+        default=True)
     on_ground = bpy.props.BoolProperty(
-                    name="On Ground",
-                    description="If enabled, root bone is on ground and only moves up at jumps",
-                    default=True)
+        name="On Ground",
+        description="If enabled, root bone is on ground and only moves up at jumps",
+        default=True)
 
     scale = bpy.props.FloatProperty(
-                    name="Scale",
-                    description="Scale down the Rig by this factor",
-                    default=1.0)
+        name="Scale",
+        description="Scale down the Rig by this factor",
+        default=1.0)
     restoffset = bpy.props.FloatVectorProperty(
-                    name="Restpose Offset",
-                    description="Offset restpose by this. Use to correct if origin is not on ground",
-                    default=(0.0, 0.0, 0.0))
+        name="Restpose Offset",
+        description="Offset restpose by this. Use to correct if origin is not on ground",
+        default=(0.0, 0.0, 0.0))
     knee_offset = bpy.props.FloatVectorProperty(
-                    name="Knee Offset",
-                    description="Offset knee joints by this. Use to fix flipping legs.",
-                    default=(0.0, 0.0, 0.0))
+        name="Knee Offset",
+        description="Offset knee joints by this. Use to fix flipping legs.",
+        default=(0.0, 0.0, 0.0))
     knee_bones = bpy.props.StringProperty(
-                    name="Knee Bones",
-                    description="Names of knee bones to offset. Seperate names with commas.",
-                    maxlen = 256,
-                    default = "RightUpLeg,LeftUpLeg",
-                    subtype='BYTE_STRING')
+        name="Knee Bones",
+        description="Names of knee bones to offset. Seperate names with commas.",
+        maxlen = 256,
+        default = "RightUpLeg,LeftUpLeg",
+        subtype='BYTE_STRING')
     force_overwrite = bpy.props.BoolProperty(
-                    name="Force Overwrite",
-                    description="If enabled, overwrites files if output path is the same as input",
-                    default=False)
+        name="Force Overwrite",
+        description="If enabled, overwrites files if output path is the same as input",
+        default=False)
 
     inpath = bpy.props.StringProperty(
-                    name="Input Path",
-                    description="Path to mixamorigs",
-                    maxlen = 256,
-                    default = "",
-                    subtype='FILE_PATH')
+        name="Input Path",
+        description="Path to mixamorigs",
+        maxlen = 256,
+        default = "",
+        subtype='FILE_PATH')
     add_leaf_bones = bpy.props.BoolProperty(
-                    name="Add Leaf Bones",
-                    description="If enabled, adds leaf bones on export when batchconverting",
-                    default=False)
+        name="Add Leaf Bones",
+        description="If enabled, adds leaf bones on export when batchconverting",
+        default=False)
     outpath = bpy.props.StringProperty(
-                    name="Output Path",
-                    description="Where Processed rigs should be saved to",
-                    maxlen = 256,
-                    default = "",
-                    subtype='FILE_PATH')
+        name="Output Path",
+        description="Where Processed rigs should be saved to",
+        maxlen = 256,
+        default = "",
+        subtype='FILE_PATH')
     ignore_leaf_bones = bpy.props.BoolProperty(
-                    name="Ignore Leaf Bones",
-                    description="Ignore leaf bones on import",
-                    default=True)
+        name="Ignore Leaf Bones",
+        description="Ignore leaf bones on import",
+        default=True)
 
     hipname = bpy.props.StringProperty(
-                    name="Hip Name",
-                    description="Additional Hipname to search for if not MixamoRig",
-                    maxlen = 256,
-                    default = "",
-                    subtype='BYTE_STRING')
+        name="Hip Name",
+        description="Additional Hipname to search for if not MixamoRig",
+        maxlen = 256,
+        default = "",
+        subtype='BYTE_STRING')
     b_remove_namespace = bpy.props.BoolProperty(
-                    name="Remove Namespace",
-                    description="Removes Naespaces from objects and bones",
-                    default=True)
+        name="Remove Namespace",
+        description="Removes Naespaces from objects and bones",
+        default=True)
+    b_unreal_bones = bpy.props.BoolProperty(
+        name="Use Unreal Engine bone schema",
+        description="Renames bones to match unreal engine schema",
+        default=False)
     fixbind = bpy.props.BoolProperty(
-                    name="Fix Bind",
-                    description="If enabled, adds a dummy mesh and binds it, to prevent loss of bindpose when exporting fbx",
-                    default=True)
+        name="Fix Bind",
+        description="If enabled, adds a dummy mesh and binds it, to prevent loss of bindpose when exporting fbx",
+        default=True)
     apply_rotation = bpy.props.BoolProperty(
-                    name="Apply Rotation",
-                    description="Applies rotation during conversion to prevent rotation and scaling issues",
-                    default=True)
+        name="Apply Rotation",
+        description="Applies rotation during conversion to prevent rotation and scaling issues",
+        default=True)
     apply_scale = bpy.props.BoolProperty(
-                    name="Apply Scale",
-                    description="Applies scale during conversion to prevent rotation and scaling issues",
-                    default=False)
+        name="Apply Scale",
+        description="Applies scale during conversion to prevent rotation and scaling issues",
+        default=False)
 
 
 class OBJECT_OT_RemoveNamespace(bpy.types.Operator):
     '''Button/Operator for removing namespaces from selection'''
     bl_idname = "mixamo.remove_namespace"
-    bl_label = "Remove Namespace"
-    description = "Removes all namespaces of selection"
-    
+    bl_label = ""
+    description = "Removes all namespaces of selection (for single Convert)"
+
     def execute(self, context):
         mixamo = context.scene.mixamo
-        if bpy.context.object == None:
+        if not bpy.context.object:
             self.report({'ERROR_INVALID_INPUT'}, "Error: no object selected.")
             return{'CANCELLED'}
         for obj in bpy.context.selected_objects:
             status = mixamoconv.remove_namespace(obj)
             if status == -1:
                 self.report({'ERROR_INVALID_INPUT'}, 'Invalid Object in selection')
-                return{'CANCELLED'}
+                return{'CANCELLED' }
         return{'FINISHED'}
+
+class OBJECT_OT_UseBlenderBoneNames(bpy.types.Operator):
+    '''Button/Operator for renaming bones to match unreal skeleton'''
+    bl_idname = "mixamo.unreal_bones"
+    bl_label = ""
+    description = "Renames bones to match the unreal skeleton (for single Convert)"
+
+    def execute(self, context):
+        mixamo = context.scene.mixamo
+        if not bpy.context.object:
+            self.report({'ERROR_INVALID_INPUT'}, "Error: no object selected.")
+            return{ 'CANCELLED'}
+        for obj in bpy.context.selected_objects:
+            status = mixamoconv.rename_bones(obj)
+            if status == -1:
+                self.report({'ERROR_INVALID_INPUT'}, 'Invalid Object in selection')
+                return{ 'CANCELLED'}
+        return{'FINISHED' }
 
 class OBJECT_OT_ConvertSingle(bpy.types.Operator):
     '''Button/Operator for converting single Rig'''
     bl_idname = "mixamo.convertsingle"
     bl_label = "Convert Single"
     description = "Bakes rootmotion for a single, already imported rig."
-    
+
     def execute(self, context):
         mixamo = context.scene.mixamo
         if bpy.context.object == None:
             self.report({'ERROR_INVALID_INPUT'}, "Error: no object selected.")
-            return{'CANCELLED'}
+            return{ 'CANCELLED'}
         if bpy.context.object.type != 'ARMATURE':
             self.report({'ERROR_INVALID_INPUT'}, "Error: %s is not an Armature." % bpy.context.object.name)
-            return{'CANCELLED'}
+            return{ 'CANCELLED'}
         if bpy.context.object.data.bones[0].name not in ('mixamorig:Hips', 'mixamorig_Hips', 'Hips', mixamo.hipname):
-            self.report({'ERROR_INVALID_INPUT'}, "Selected object %s is not a Mixamo rig, or at least naming does not match!" % bpy.context.object.name)
-            return{'CANCELLED'}
+            self.report({'ERROR_INVALID_INPUT'},
+                        "Selected object %s is not a Mixamo rig, or at least naming does not match!" % bpy.context.object.name)
+            return{ 'CANCELLED'}
         status = mixamoconv.hip_to_root(
             armature = bpy.context.object,
             use_x = mixamo.use_x,
-            use_y = mixamo.use_y,
-            use_z = mixamo.use_z,
-            on_ground = mixamo.on_ground,
-            scale = mixamo.scale,
-            restoffset = mixamo.restoffset,
-            hipname = mixamo.hipname,
-            fixbind = mixamo.fixbind,
-            apply_rotation = mixamo.apply_rotation,
-            apply_scale = mixamo.apply_scale)
+            use_y =mixamo.use_y,
+            use_z =mixamo.use_z,
+            on_ground =mixamo.on_ground,
+            scale =mixamo.scale,
+            restoffset =mixamo.restoffset,
+            hipname =mixamo.hipname,
+            fixbind =mixamo.fixbind,
+            apply_rotation =mixamo.apply_rotation,
+            apply_scale =mixamo.apply_scale)
         if status == -1:
             self.report({'ERROR_INVALID_INPUT'}, 'Error: Hips not found')
-            return{'CANCELLED'}
+            return{ 'CANCELLED'}
         self.report({'INFO'}, "Rig Converted")
-        return{'FINISHED'}
+        return{ 'FINISHED'}
+
 
 class OBJECT_OT_ApplyRestoffset(bpy.types.Operator):
     '''Button/Operator for converting single Rig'''
     bl_idname = "mixamo.apply_restoffset"
     bl_label = "Apply Restoffset"
     description = "Applies Restoffset to restpose and corrects animation"
-    
+
     def execute(self, context):
         mixamo = context.scene.mixamo
         if bpy.context.object == None:
             self.report({'ERROR_INVALID_INPUT'}, "Error: no object selected.")
-            return{'CANCELLED'}
+            return{ 'CANCELLED'}
         if bpy.context.object.type != 'ARMATURE':
             self.report({'ERROR_INVALID_INPUT'}, "Error: %s is not an Armature." % bpy.context.object.name)
-            return{'CANCELLED'}
+            return{ 'CANCELLED'}
         if bpy.context.object.data.bones[0].name not in ('mixamorig:Hips', 'mixamorig_Hips', 'Hips', mixamo.hipname):
-            self.report({'ERROR_INVALID_INPUT'}, "Selected object %s is not a Mixamo rig, or at least naming does not match!" % bpy.context.object.name)
-            return{'CANCELLED'}
+            self.report({'ERROR_INVALID_INPUT'},
+                        "Selected object %s is not a Mixamo rig, or at least naming does not match!" % bpy.context.object.name)
+            return{ 'CANCELLED'}
         status = mixamoconv.apply_restoffset(bpy.context.object, bpy.context.object.data.bones[0], mixamo.restoffset)
         if status == -1:
             self.report({'ERROR_INVALID_INPUT'}, 'apply_restoffset Failed')
-            return{'CANCELLED'}
-        return{'FINISHED'}
-        
+            return{ 'CANCELLED'}
+        return{ 'FINISHED'}
+
+
 class OBJECT_OT_ConvertBatch(bpy.types.Operator):
     '''Button/Operator for starting batch conversion'''
     bl_idname = "mixamo.convertbatch"
     bl_label = "Batch Convert"
     description = "Converts all mixamorigs from the [Input Path] and exports them to the [Ouput Path]"
-    
+
     def execute(self, context):
         mixamo = context.scene.mixamo
         inpath = mixamo.inpath
         outpath = mixamo.outpath
         if inpath == '':
             self.report({'ERROR_INVALID_INPUT'}, "Error: no Input Path set.")
-            return{'CANCELLED'}
+            return{ 'CANCELLED'}
         if outpath == '':
             self.report({'ERROR_INVALID_INPUT'}, "Error: no Output Path set.")
-            return{'CANCELLED'}
+            return{ 'CANCELLED'}
         if (inpath == outpath) and not mixamo.force_overwrite:
-            self.report({'ERROR_INVALID_INPUT'}, "Input and Output path are the same, source files would be overwritten.")
-            return{'CANCELLED'}
+            self.report({'ERROR_INVALID_INPUT'},
+                        "Input and Output path are the same, source files would be overwritten.")
+            return{ 'CANCELLED'}
         if (inpath == outpath) & mixamo.force_overwrite:
             self.report({'WARNING'}, "Input and Output path are the same, source files will be overwritten.")
         numfiles = mixamoconv.batch_hip_to_root(
             bpy.path.abspath(inpath),
             bpy.path.abspath(outpath),
-            use_x = mixamo.use_x,
-            use_y = mixamo.use_y,
-            use_z = mixamo.use_z,
-            on_ground = mixamo.on_ground,
-            scale = mixamo.scale,
-            restoffset = mixamo.restoffset,
-            hipname = mixamo.hipname,
-            fixbind = mixamo.fixbind,
-            apply_rotation = mixamo.apply_rotation,
-            apply_scale = mixamo.apply_scale,
-            b_remove_namespace = mixamo.b_remove_namespace,
-            add_leaf_bones = mixamo.add_leaf_bones,
-            knee_offset = mixamo.knee_offset,
-            ignore_leaf_bones = mixamo.ignore_leaf_bones)
+            use_x =mixamo.use_x,
+            use_y =mixamo.use_y,
+            use_z =mixamo.use_z,
+            on_ground =mixamo.on_ground,
+            scale =mixamo.scale,
+            restoffset =mixamo.restoffset,
+            hipname =mixamo.hipname,
+            fixbind =mixamo.fixbind,
+            apply_rotation =mixamo.apply_rotation,
+            apply_scale =mixamo.apply_scale,
+            b_remove_namespace =mixamo.b_remove_namespace,
+            add_leaf_bones =mixamo.add_leaf_bones,
+            knee_offset =mixamo.knee_offset,
+            ignore_leaf_bones =mixamo.ignore_leaf_bones)
         if numfiles == -1:
             self.report({'ERROR_INVALID_INPUT'}, 'Error: Hips not found')
-            return{'CANCELLED'}
+            return{ 'CANCELLED'}
         self.report({'INFO'}, "%d files converted" % numfiles)
-        return{'FINISHED'}
+        return{ 'FINISHED'}
+
 
 class MixamoconvPanel(bpy.types.Panel):
     """Creates a Tab in the Toolshelve in 3D_View"""
@@ -263,7 +291,7 @@ class MixamoconvPanel(bpy.types.Panel):
         layout = self.layout
 
         scene = bpy.context.scene
-        
+
         ''' Annoying warning Box
         #box with general info
         infobox = layout.box()
@@ -273,44 +301,55 @@ class MixamoconvPanel(bpy.types.Panel):
         row = infobox.row()
         row.label("Only use in empty or startup scene")
         '''
-        
+
         box = layout.box()
         # Options for how to do the conversion
         row = box.row()
-        row.prop(scene.mixamo, "use_z", toggle = True)
+        row.prop(scene.mixamo, "use_z", toggle =True)
         if scene.mixamo.use_z:
-            row.prop(scene.mixamo, "on_ground", toggle = True)
-        
+            row.prop(scene.mixamo, "on_ground", toggle =True)
+
         # Button for conversion of single Selected rig
         row = box.row()
         row.scale_y = 2.0
         row.operator("mixamo.convertsingle")
-        
+
         box = layout.box()
         row = box.row()
         row.prop(scene.mixamo, "advanced", toggle=True)
-        row = box.row()
-        #row.prop(scene.mixamo, "mode")
+
+        # row.prop(scene.mixamo, "mode")
         if scene.mixamo.advanced:
             split = box.split()
-            col = split.column(align = True)
-            col.prop(scene.mixamo, "use_x", toggle = True)
-            col.prop(scene.mixamo, "use_y", toggle = True)
-            col.prop(scene.mixamo, "use_z", toggle = True)
+            col = split.column(align =True)
+            col.prop(scene.mixamo, "use_x", toggle =True)
+            col.prop(scene.mixamo, "use_y", toggle =True)
+            col.prop(scene.mixamo, "use_z", toggle =True)
+
+            box.label(text="Bone names:")
+            box.prop(scene.mixamo, "hipname")
+
             row = box.row()
-            row.prop(scene.mixamo, "hipname")
+            row.prop(scene.mixamo, 'b_remove_namespace', text="Remove Namespaces")
+            row.operator("mixamo.remove_namespace", icon='PLAY')
+            row.enabled = not scene.mixamo.b_unreal_bones
+
             row = box.row()
-            row.prop(scene.mixamo, 'b_remove_namespace', text="")
-            row.operator("mixamo.remove_namespace")
-            #row = box.row()
+            row.prop(scene.mixamo, 'b_unreal_bones', text="Use Unreal Engine bone names")
+            row.operator("mixamo.unreal_bones", icon='PLAY')
+            row.enabled = not scene.mixamo.b_remove_namespace
+
+            box.label(text="Fixes:")
+            row = box.row()
             row.prop(scene.mixamo, "fixbind")
-            
-            row = box.row()
             row.prop(scene.mixamo, "apply_rotation")
-            row.prop(scene.mixamo, "apply_scale")
+
             row = box.row()
-            row.prop(scene.mixamo, "scale")
-            #box = box.box()
+            row.prop(scene.mixamo, "apply_scale")
+            if scene.mixamo.apply_scale:
+                row.prop(scene.mixamo, "scale")
+
+            # box = box.box()
             row = box.row()
             row.prop(scene.mixamo, "experimental", toggle=True, icon='ERROR')
             if scene.mixamo.experimental:
@@ -318,28 +357,28 @@ class MixamoconvPanel(bpy.types.Panel):
                 split = box.split()
                 col = split.column()
                 col.prop(scene.mixamo, "restoffset")
-                #row = box.row()
+                # row = box.row()
                 col.operator("mixamo.apply_restoffset")
                 col = split.column()
                 col.prop(scene.mixamo, "knee_offset")
                 col.prop(scene.mixamo, "knee_bones")
-        
+
         box = layout.box()
         # input and output paths for batch conversion
         box.label(text="Batch")
         split = box.split()
         col = split.column()
         col.prop(scene.mixamo, "inpath")
-        
-        #row = box.row()
+
+        # row = box.row()
         col.prop(scene.mixamo, "outpath")
         if scene.mixamo.advanced:
             col = split.column()
             col.prop(scene.mixamo, "ignore_leaf_bones")
             col.prop(scene.mixamo, "add_leaf_bones")
-        row = box.row()
+
         box.prop(scene.mixamo, "force_overwrite")
-        
+
         # button to start batch conversion
         row = box.row()
         row.scale_y = 2.0
@@ -357,6 +396,7 @@ def register():
     bpy.utils.register_class(MixamoconvPanel)
     '''
 
+
 def unregister():
     bpy.utils.unregister_module(__name__)
     '''
@@ -365,7 +405,9 @@ def unregister():
     bpy.utils.register_class(OBJECT_OT_ConvertBatch)
     bpy.utils.unregister_class(MixamoconvPanel)
     '''
+
+
 if __name__ == "__main__":
     register()
-    
-    
+
+

--- a/mixamoconv.py
+++ b/mixamoconv.py
@@ -23,10 +23,13 @@ import bpy
 from bpy_types import Object
 import os
 import re
+import logging
 
-def remove_namespace(s = ''):
+log = logging.getLogger(__name__)
+
+def remove_namespace(s=''):
     """function for removing all namespaces from strings, objects or even armatrure bones"""
-    
+
     if type(s) == str:
         i = re.search(r"[:_]", s[::-1])
         if i:
@@ -43,25 +46,107 @@ def remove_namespace(s = ''):
     return -1
 
 
+def rename_bones(s='', t='unreal'):
+    """function for renaming the armature bones to a target skeleton"""
+    unreal = {
+        'root': 'Root',
+        'Hips': 'Pelvis',
+        'Spine': 'spine_01',
+        'Spine1': 'spine_02',
+        'Spine2': 'spine_03',
+        'LeftShoulder': 'clavicle_l',
+        'LeftArm': 'upperarm_l',
+        'LeftForeArm': 'lowerarm_l',
+        'LeftHand': 'hand_l',
+        'RightShoulder': 'clavicle_r',
+        'RightArm': 'upperarm_r',
+        'RightForeArm': 'lowerarm_r',
+        'RightHand': 'hand_r',
+        'Neck1': 'neck_01',
+        'Neck': 'neck_01',
+        'Head': 'head',
+        'LeftUpLeg': 'thigh_l',
+        'LeftLeg': 'calf_l',
+        'LeftFoot': 'foot_l',
+        'RightUpLeg': 'thigh_r',
+        'RightLeg': 'calf_r',
+        'RightFoot': 'foot_r',
+        'LeftHandIndex1': 'index_01_l',
+        'LeftHandIndex2': 'index_02_l',
+        'LeftHandIndex3': 'index_03_l',
+        'LeftHandMiddle1': 'middle_01_l',
+        'LeftHandMiddle2': 'middle_02_l',
+        'LeftHandMiddle3': 'middle_03_l',
+        'LeftHandPinky1': 'pinky_01_l',
+        'LeftHandPinky2': 'pinky_02_l',
+        'LeftHandPinky3': 'pinky_03_l',
+        'LeftHandRing1': 'ring_01_l',
+        'LeftHandRing2': 'ring_02_l',
+        'LeftHandRing3': 'ring_03_l',
+        'LeftHandThumb1': 'thumb_01_l',
+        'LeftHandThumb2': 'thumb_02_l',
+        'LeftHandThumb3': 'thumb_03_l',
+        'LeftHand': 'lowerarm_twist_01_l',
+        'LeftArm': 'upperarm_twist_01_l',
+        'RightHandIndex1': 'index_01_r',
+        'RightHandIndex2': 'index_02_r',
+        'RightHandIndex3': 'index_03_r',
+        'RightHandMiddle1': 'middle_01_r',
+        'RightHandMiddle2': 'middle_02_r',
+        'RightHandMiddle3': 'middle_03_r',
+        'RightHandPinky1': 'pinky_01_r',
+        'RightHandPinky2': 'pinky_02_r',
+        'RightHandPinky3': 'pinky_03_r',
+        'RightHandRing1': 'ring_01_r',
+        'RightHandRing2': 'ring_02_r',
+        'RightHandRing3': 'ring_03_r',
+        'RightHandThumb1': 'thumb_01_r',
+        'RightHandThumb2': 'thumb_02_r',
+        'RightHandThumb3': 'thumb_03_r',
+        'RightHand': 'lowerarm_twist_01_r',
+        'RightArm': 'upperarm_twist_01_r',
+        'LeftToeBase': 'ball_l',
+        'LeftUpLeg': 'thigh_twist_01_l',
+        'RightToeBase': 'ball_r',
+        'RightUpLeg': 'thigh_twist_01_r'
+    }
+    schema = {'unreal': unreal }
+    if type(s) == str:
+        i = schema[t].get(s)
+        if i:
+            return i
+        else:
+            log.warning('WARNING %s bone is missing', s)
+            return s
+    elif type(s) == Object:
+        if s.type == 'ARMATURE':
+            for bone in s.data.bones:
+                bone.name = rename_bones(remove_namespace(bone.name))
+        s.name = rename_bones(s.name)
+        return 1
+    return -1
+
 def apply_restoffset(armature, hipbone, restoffset):
     """function to apply restoffset to rig, should be used if rest-/bindpose does not stand on ground with feet"""
     # apply rest offset to restpose
     bpy.context.scene.objects.active = armature
     bpy.ops.object.mode_set(mode='EDIT')
     bpy.ops.armature.select_all(action='SELECT')
-    bpy.ops.transform.translate(value=restoffset, constraint_axis=(False, False, False), constraint_orientation='GLOBAL', mirror=False, proportional='DISABLED', proportional_edit_falloff='SMOOTH', proportional_size=1)
+    bpy.ops.transform.translate(value=restoffset, constraint_axis=(False, False, False),
+                                constraint_orientation='GLOBAL', mirror=False, proportional='DISABLED',
+                                proportional_edit_falloff='SMOOTH', proportional_size=1)
     bpy.ops.object.mode_set(mode='OBJECT')
 
     # apply restoffset to animation of hip
     restoffset_local = (restoffset[0], restoffset[2], -restoffset[1])
     for axis in range(3):
-        fcurve = armature.animation_data.action.fcurves.find("pose.bones[\""+hipbone.name+"\"].location", axis)
+        fcurve = armature.animation_data.action.fcurves.find("pose.bones[\"" + hipbone.name + "\"].location", axis)
         for pi in range(len(fcurve.keyframe_points)):
-            fcurve.keyframe_points[pi].co.y -= restoffset_local[axis]/armature.scale.x
+            fcurve.keyframe_points[pi].co.y -= restoffset_local[axis] / armature.scale.x
     return 1
 
 
-def apply_kneefix(armature, offset, bonenames = ['RightUpLeg', 'LeftUpLeg']):
+def apply_kneefix(armature, offset, bonenames=['RightUpLeg', 'LeftUpLeg']):
     """workaround for flickering knees after export (moves joints in restpose by offset, can break animation)"""
     bpy.context.scene.objects.active = armature
     bpy.ops.object.mode_set(mode='EDIT')
@@ -73,36 +158,39 @@ def apply_kneefix(armature, offset, bonenames = ['RightUpLeg', 'LeftUpLeg']):
     return 1
 
 
-def hip_to_root(armature, use_x = True, use_y = True, use_z = True, on_ground = True, scale = 1.0, restoffset = (0,0,0), hipname='', fixbind = True, apply_rotation = True, apply_scale = False):
+def hip_to_root(armature, use_x=True, use_y=True, use_z=True, on_ground=True, scale=1.0, restoffset=(0, 0, 0),
+                hipname='', fixbind=True, apply_rotation=True, apply_scale=False):
     """function to bake hipmotion to RootMotion in MixamoRigs"""
-    
+
     root = armature
     root.name = "root"
     framerange = root.animation_data.action.frame_range
-    
+
     for hipname in ('Hips', 'mixamorig:Hips', 'mixamorig_Hips', hipname):
         hips = root.pose.bones.get(hipname)
         if hips != None:
             break
     if hips == None:
         return -1
-    
-    #Scale by ScaleFactor
+
+    # Scale by ScaleFactor
     if scale != 1.0:
         for i in range(3):
             fcurve = root.animation_data.action.fcurves.find('scale', i)
             if fcurve != None:
                 root.animation_data.action.fcurves.remove(fcurve)
         root.scale *= scale
-    
-    #apply restoffset to restpose and correct animation
+
+    # apply restoffset to restpose and correct animation
     apply_restoffset(root, hips, restoffset)
-    
+
     hiplocation_world = root.matrix_local * hips.bone.head
     z_offset = hiplocation_world[2]
-    
-    #Create helper to bake the root motion
-    bpy.ops.object.empty_add(type='PLAIN_AXES', radius=1, view_align=False, location=(0, 0, 0), layers=(True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False))
+
+    # Create helper to bake the root motion
+    bpy.ops.object.empty_add(type='PLAIN_AXES', radius=1, view_align=False, location=(0, 0, 0), layers=(
+    True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False,
+    False, False, False, False))
     rootBaker = bpy.context.object
     rootBaker.name = "rootBaker"
 
@@ -120,7 +208,7 @@ def hip_to_root(armature, use_x = True, use_y = True, use_z = True, on_ground = 
             print("using on ground")
             rootBaker.location[2] = -z_offset
             bpy.ops.object.constraint_add(type='LIMIT_LOCATION')
-            bpy.context.object.constraints["Limit Location"].use_min_z = True        
+            bpy.context.object.constraints["Limit Location"].use_min_z = True
 
     bpy.ops.object.constraint_add(type='COPY_LOCATION')
     bpy.context.object.constraints["Copy Location"].use_x = use_x
@@ -135,10 +223,13 @@ def hip_to_root(armature, use_x = True, use_y = True, use_z = True, on_ground = 
     bpy.context.object.constraints["Copy Rotation"].use_y = False
     bpy.context.object.constraints["Copy Rotation"].use_x = False
 
-    bpy.ops.nla.bake(frame_start=framerange[0], frame_end=framerange[1], step=1, only_selected=True, visual_keying=True, clear_constraints=True, clear_parents=False, use_current_action=False, bake_types={'OBJECT'})
+    bpy.ops.nla.bake(frame_start=framerange[0], frame_end=framerange[1], step=1, only_selected=True, visual_keying=True,
+                     clear_constraints=True, clear_parents=False, use_current_action=False, bake_types={'OBJECT'})
 
-    #Create helper to bake hipmotion in Worldspace
-    bpy.ops.object.empty_add(type='PLAIN_AXES', radius=1, view_align=False, location=(0, 0, 0), layers=(True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False))
+    # Create helper to bake hipmotion in Worldspace
+    bpy.ops.object.empty_add(type='PLAIN_AXES', radius=1, view_align=False, location=(0, 0, 0), layers=(
+    True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False,
+    False, False, False, False))
     hipsBaker = bpy.context.object
     hipsBaker.name = "hipsBaker"
 
@@ -150,16 +241,17 @@ def hip_to_root(armature, use_x = True, use_y = True, use_z = True, on_ground = 
     bpy.context.object.constraints["Copy Rotation"].target = root
     bpy.context.object.constraints["Copy Rotation"].subtarget = hips.name
 
-    bpy.ops.nla.bake(frame_start=framerange[0], frame_end=framerange[1], step=1, only_selected=True, visual_keying=True, clear_constraints=True, clear_parents=False, use_current_action=False, bake_types={'OBJECT'})
+    bpy.ops.nla.bake(frame_start=framerange[0], frame_end=framerange[1], step=1, only_selected=True, visual_keying=True,
+                     clear_constraints=True, clear_parents=False, use_current_action=False, bake_types={'OBJECT'})
 
-    #select armature
+    # select armature
     root.select = True
     bpy.context.scene.objects.active = root
-    
+
     if apply_rotation or apply_scale:
         bpy.ops.object.transform_apply(location=False, rotation=apply_rotation, scale=apply_scale)
-    
-    #Bake Root motion to Armature (root)
+
+    # Bake Root motion to Armature (root)
     bpy.ops.object.constraint_add(type='COPY_LOCATION')
     bpy.context.object.constraints["Copy Location"].target = rootBaker
 
@@ -167,10 +259,10 @@ def hip_to_root(armature, use_x = True, use_y = True, use_z = True, on_ground = 
     bpy.context.object.constraints["Copy Rotation"].target = bpy.data.objects["rootBaker"]
     bpy.context.object.constraints["Copy Rotation"].use_offset = True
 
-    bpy.ops.nla.bake(frame_start=framerange[0], frame_end=framerange[1], step=1, only_selected=True, visual_keying=True, clear_constraints=True, clear_parents=False, use_current_action=True, bake_types={'OBJECT'})
+    bpy.ops.nla.bake(frame_start=framerange[0], frame_end=framerange[1], step=1, only_selected=True, visual_keying=True,
+                     clear_constraints=True, clear_parents=False, use_current_action=True, bake_types={'OBJECT'})
 
-
-    bpy.ops.object.mode_set(mode = 'POSE')
+    bpy.ops.object.mode_set(mode='POSE')
     hips.bone.select = True
     root.data.bones.active = hips.bone
 
@@ -179,19 +271,18 @@ def hip_to_root(armature, use_x = True, use_y = True, use_z = True, on_ground = 
     bpy.ops.pose.constraint_add(type='COPY_ROTATION')
     hips.constraints["Copy Rotation"].target = hipsBaker
 
-    bpy.ops.nla.bake(frame_start=framerange[0], frame_end=framerange[1], step=1, only_selected=True, visual_keying=True, clear_constraints=True, clear_parents=False, use_current_action=True, bake_types={'POSE'})
-    
-    
-    
-    #Delete helpers
-    bpy.ops.object.mode_set(mode = 'OBJECT')
+    bpy.ops.nla.bake(frame_start=framerange[0], frame_end=framerange[1], step=1, only_selected=True, visual_keying=True,
+                     clear_constraints=True, clear_parents=False, use_current_action=True, bake_types={'POSE'})
+
+    # Delete helpers
+    bpy.ops.object.mode_set(mode='OBJECT')
     bpy.ops.object.select_all(action='DESELECT')
 
     hipsBaker.select = True
     rootBaker.select = True
 
     bpy.ops.object.delete(use_global=False)
-    
+
     # bind armature to dummy mesh if it doesn't have any
     if fixbind:
         bindmesh = None
@@ -203,7 +294,10 @@ def hip_to_root(armature, use_x = True, use_y = True, use_z = True, on_ground = 
                         break
         if bindmesh == None:
             bpy.ops.object.select_all(action='DESELECT')
-            bpy.ops.mesh.primitive_plane_add(radius=1, view_align=False, enter_editmode=False, location=(0, 0, 0), layers=(True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False))
+            bpy.ops.mesh.primitive_plane_add(radius=1, view_align=False, enter_editmode=False, location=(0, 0, 0),
+                                             layers=(
+                                             True, False, False, False, False, False, False, False, False, False, False,
+                                             False, False, False, False, False, False, False, False, False))
             binddummy = bpy.context.object
             binddummy.name = 'binddummy'
             root.select = True
@@ -213,12 +307,15 @@ def hip_to_root(armature, use_x = True, use_y = True, use_z = True, on_ground = 
             bindmesh.select = True
             bpy.context.scene.objects.active = bindmesh
             bpy.ops.object.transform_apply(location=False, rotation=apply_rotation, scale=apply_scale)
-    
+
     return 1
 
-def batch_hip_to_root(source_dir, dest_dir, use_x = True, use_y = True, use_z = True, on_ground = True, scale = 1.0, restoffset = (0,0,0), hipname = '', fixbind = True, apply_rotation = True, apply_scale = False, b_remove_namespace = True, add_leaf_bones = False, knee_offset = (0,0,0), ignore_leaf_bones = True):
+
+def batch_hip_to_root(source_dir, dest_dir, use_x=True, use_y=True, use_z=True, on_ground=True, scale=1.0,
+                      restoffset=(0, 0, 0), hipname='', fixbind=True, apply_rotation=True, apply_scale=False,
+                      b_remove_namespace=True, add_leaf_bones=False, knee_offset=(0, 0, 0), ignore_leaf_bones=True):
     """Batch Convert MixamoRigs"""
-    
+
     bpy.context.scene.unit_settings.system = 'METRIC'
     bpy.context.scene.unit_settings.scale_length = 1
 
@@ -229,17 +326,17 @@ def batch_hip_to_root(source_dir, dest_dir, use_x = True, use_y = True, use_z = 
             ".fbx": lambda filename: bpy.ops.import_scene.fbx(filepath=filename, axis_forward='-Z',
                                                               axis_up='Y', directory="",
                                                               filter_glob="*.fbx", ui_tab='MAIN',
-                                                              use_manual_orientation=False, global_scale=1,
+                                                              use_manual_orientation=False, global_scale=1.0,
                                                               bake_space_transform=False,
                                                               use_custom_normals=True,
                                                               use_image_search=True,
-                                                              use_alpha_decals=False, decal_offset=0,
-                                                              use_anim=True, anim_offset=1,
+                                                              use_alpha_decals=False, decal_offset=0.0,
+                                                              use_anim=True, anim_offset=1.0,
                                                               use_custom_props=True,
                                                               use_custom_props_enum_as_string=True,
-                                                              ignore_leaf_bones=ignore_leaf_bones,
+                                                              ignore_leaf_bones=False,
                                                               force_connect_children=False,
-                                                              automatic_bone_orientation=False,
+                                                              automatic_bone_orientation=True,
                                                               primary_bone_axis='Y',
                                                               secondary_bone_axis='X',
                                                               use_prepost_rot=True),
@@ -261,32 +358,36 @@ def batch_hip_to_root(source_dir, dest_dir, use_x = True, use_y = True, use_z = 
             bpy.ops.object.select_all(action='SELECT')
             bpy.ops.object.delete(use_global=True)
 
-            #remove all datablocks
+            # remove all datablocks
             for mesh in bpy.data.meshes:
                 bpy.data.meshes.remove(mesh, do_unlink=True)
             for material in bpy.data.materials:
                 bpy.data.materials.remove(material, do_unlink=True)
             for action in bpy.data.actions:
-                    bpy.data.actions.remove(action, do_unlink=True)
+                bpy.data.actions.remove(action, do_unlink=True)
 
-            #import FBX
+            # import FBX
             file_loader[file_ext](file.path)
 
-            #namespace removal
+            # namespace removal
             if b_remove_namespace:
                 for obj in bpy.context.selected_objects:
                     remove_namespace(obj)
-            
+
             def getArmature(objects):
                 for a in objects:
                     if a.type == 'ARMATURE':
                         return a
+
             armature = getArmature(bpy.context.selected_objects)
-            #do hip to Root conversion
-            if hip_to_root(armature, use_x = use_x, use_y = use_y, use_z = use_z, on_ground = on_ground, scale = scale, restoffset = restoffset, hipname = hipname, fixbind = fixbind, apply_rotation = apply_rotation, apply_scale = apply_scale) == -1:
+            # do hip to Root conversion
+            if hip_to_root(armature, use_x=use_x, use_y=use_y, use_z=use_z, on_ground=on_ground, scale=scale,
+                           restoffset=restoffset, hipname=hipname, fixbind=fixbind, apply_rotation=apply_rotation,
+                           apply_scale=apply_scale) == -1:
                 return -1
-            apply_kneefix(armature, knee_offset, bonenames = bpy.context.scene.mixamo.knee_bones.decode('utf-8').split(','))
-            #remove newly created orphan actions
+            apply_kneefix(armature, knee_offset,
+                          bonenames=bpy.context.scene.mixamo.knee_bones.decode('utf-8').split(','))
+            # remove newly created orphan actions
             for action in bpy.data.actions:
                 if action != armature.animation_data.action:
                     bpy.data.actions.remove(action, do_unlink=True)
@@ -294,13 +395,14 @@ def batch_hip_to_root(source_dir, dest_dir, use_x = True, use_y = True, use_z = 
             # store file to disk
             output_file = dest_dir + file.name[:-3] + ".fbx"
             bpy.ops.export_scene.fbx(filepath=output_file,
-                version = 'BIN7400',
-                use_selection=False,
-                apply_unit_scale=False,
-                add_leaf_bones=add_leaf_bones)
+                                     version='BIN7400',
+                                     use_selection=False,
+                                     apply_unit_scale=False,
+                                     add_leaf_bones=add_leaf_bones)
             bpy.ops.object.select_all(action='SELECT')
             bpy.ops.object.delete(use_global=False)
     return numfiles
+
 
 if __name__ == "__main__":
     print("mixamoconv Hello.")


### PR DESCRIPTION
… a little bit

Here is the the new UI look
The part of UI which has been modified is in advance settings. You can see the options related to bone names have been grouped and rename bones to unreal options is now there.
The latter option is not compatible with removing *mixamo* prefix since both output different names.
For this reason when one is active the other is grayed out.
The play buttons allow user to perform those action when in 'convert single' mode.

![image](https://user-images.githubusercontent.com/576580/31913664-8b1f4fa0-b850-11e7-96ad-3eaa0787ce45.png)

Implements feature in #16
The reformatting is for PEP8 and makes Pycham happy