### PR TITLE
Fixed Root motion rotation glitch #23

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 '''
+    Copyright (C) 2017-2018  Antonio 'GNUton' Aloisio
     Copyright (C) 2017  Enzio Probst
 
     Created by Enzio Probst
@@ -22,7 +23,7 @@
 bl_info = {
     "name": "Mixamo Converter",
     "author": "Enzio Probst",
-    "version": (1, 0, 8),
+    "version": (1, 0, 9),
     "blender": (2, 7, 8),
     "location": "3D View > Tool Shelve > Mixamo Tab",
     "description": ("Script to bake Root motion for Mixamo Animations"),
@@ -33,7 +34,16 @@ bl_info = {
 }
 
 import bpy
-from . import mixamoconv
+
+try:
+    from . import mixamoconv
+except SystemError:
+    import mixamoconv
+
+if "bpy" in locals():
+    from importlib import reload
+    if "mixamoconv" in locals():
+        reload(mixamoconv)
 
 class MixamoPropertyGroup(bpy.types.PropertyGroup):
     '''Property container for options and paths of mixamo Converter'''
@@ -180,7 +190,7 @@ class OBJECT_OT_ConvertSingle(bpy.types.Operator):
     def execute(self, context):
         mixamo = context.scene.mixamo
         if bpy.context.object == None:
-            self.report({'ERROR_INVALID_INPUT'}, "Error: no object selected.")
+            self.report({'ERROR_INVALID_INPUT'}, "Error: no object selected. Please select the Armature object.")
             return{ 'CANCELLED'}
         if bpy.context.object.type != 'ARMATURE':
             self.report({'ERROR_INVALID_INPUT'}, "Error: %s is not an Armature." % bpy.context.object.name)

--- a/mixamoconv.py
+++ b/mixamoconv.py
@@ -215,12 +215,6 @@ def hip_to_root(armature, use_x=True, use_y=True, use_z=True, on_ground=True, sc
     bpy.context.object.constraints["Copy Location"].target = root
     bpy.context.object.constraints["Copy Location"].subtarget = hips.name
 
-    bpy.ops.object.constraint_add(type='COPY_ROTATION')
-    bpy.context.object.constraints["Copy Rotation"].target = root
-    bpy.context.object.constraints["Copy Rotation"].subtarget = hips.name
-    bpy.context.object.constraints["Copy Rotation"].use_y = False
-    bpy.context.object.constraints["Copy Rotation"].use_x = False
-
     bpy.ops.nla.bake(frame_start=framerange[0], frame_end=framerange[1], step=1, only_selected=True, visual_keying=True,
                      clear_constraints=True, clear_parents=False, use_current_action=False, bake_types={'OBJECT'})
 
@@ -252,10 +246,6 @@ def hip_to_root(armature, use_x=True, use_y=True, use_z=True, on_ground=True, sc
     # Bake Root motion to Armature (root)
     bpy.ops.object.constraint_add(type='COPY_LOCATION')
     bpy.context.object.constraints["Copy Location"].target = rootBaker
-
-    bpy.ops.object.constraint_add(type='COPY_ROTATION')
-    bpy.context.object.constraints["Copy Rotation"].target = bpy.data.objects["rootBaker"]
-    bpy.context.object.constraints["Copy Rotation"].use_offset = True
 
     bpy.ops.nla.bake(frame_start=framerange[0], frame_end=framerange[1], step=1, only_selected=True, visual_keying=True,
                      clear_constraints=True, clear_parents=False, use_current_action=True, bake_types={'OBJECT'})


### PR DESCRIPTION
Removed copy rotation constraints. Not sure if this is gonna break something.

Can this break something? 
@enziop if you have a few mins would you double check that this is right?  do you remember the reason why those constrains were added in the first place for the root bone?