### PR TITLE
Foot bone workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,10 @@ Very kludgy workaround which can result in bones being out of place in animation
 Can be used to fix rotational flickering occuring in some animations after export (seems to be an exporter bug). (mostly observed on legs but can be used on any bones)
 It moves the tip joint of given bones by the given vector in the restpose.
 
+#### Option [Foot Bone Workaround]
+Workaround which attempts to fix the twisting of the foot bones (specifically, LeftToeBase/ball_l and RightToeBase/ball_r) of certain meshes,
+which may appear rotated by 180 degrees after conversion.
+
 ### Batch Conversion:
 * Here you can specify an Input- and Outputpath for Batchconversion
 * the output files will have the same names as the input files, existing files will be overwritten

--- a/__init__.py
+++ b/__init__.py
@@ -164,6 +164,10 @@ class MixamoPropertyGroup(bpy.types.PropertyGroup):
         name="Quaternion Clean Post",
         description="Performs quaternion cleanup after conversion",
         default=True)
+    foot_bone_workaround = bpy.props.BoolProperty(
+        name="Foot Bone Workaround",
+        description="Attempts to fix twisting of the foot bones",
+        default=False)
 
 
 class OBJECT_OT_RemoveNamespace(bpy.types.Operator):
@@ -231,7 +235,8 @@ class OBJECT_OT_ConvertSingle(bpy.types.Operator):
             apply_rotation = mixamo.apply_rotation,
             apply_scale = mixamo.apply_scale,
             quaternion_clean_pre=mixamo.quaternion_clean_pre,
-            quaternion_clean_post=mixamo.quaternion_clean_post)
+            quaternion_clean_post=mixamo.quaternion_clean_post,
+            foot_bone_workaround=mixamo.foot_bone_workaround)
 
         try:
             for status in mixamoconv_iterator:
@@ -278,7 +283,8 @@ class OBJECT_OT_ConvertSingleStepwise(bpy.types.Operator):
                 apply_rotation = mixamo.apply_rotation,
                 apply_scale = mixamo.apply_scale,
                 quaternion_clean_pre=mixamo.quaternion_clean_pre,
-                quaternion_clean_post=mixamo.quaternion_clean_post)
+                quaternion_clean_post=mixamo.quaternion_clean_post,
+                foot_bone_workaround=mixamo.foot_bone_workaround)
             self.report({'INFO'}, "New conversion started")
         try:
             try:
@@ -363,7 +369,8 @@ class OBJECT_OT_ConvertBatch(bpy.types.Operator):
             ignore_leaf_bones = mixamo.ignore_leaf_bones,
             automatic_bone_orientation = mixamo.automatic_bone_orientation,
             quaternion_clean_pre=mixamo.quaternion_clean_pre,
-            quaternion_clean_post=mixamo.quaternion_clean_post)
+            quaternion_clean_post=mixamo.quaternion_clean_post,
+            foot_bone_workaround=mixamo.foot_bone_workaround)
         if numfiles == -1:
             self.report({'ERROR_INVALID_INPUT'}, 'Error: Not all files could be converted, look in console for more information')
             return{ 'CANCELLED'}
@@ -429,7 +436,8 @@ class MixamoconvPanel(bpy.types.Panel):
             # row = box.row()
             # row.prop(scene.mixamo, "quaternion_clean_pre")
             # row.prop(scene.mixamo, "quaternion_clean_post")
-
+            row = box.row()
+            row.prop(scene.mixamo, "foot_bone_workaround")
 
             row = box.row()
             row.prop(scene.mixamo, "apply_scale")

--- a/__init__.py
+++ b/__init__.py
@@ -436,8 +436,6 @@ class MixamoconvPanel(bpy.types.Panel):
             # row = box.row()
             # row.prop(scene.mixamo, "quaternion_clean_pre")
             # row.prop(scene.mixamo, "quaternion_clean_post")
-            row = box.row()
-            row.prop(scene.mixamo, "foot_bone_workaround")
 
             row = box.row()
             row.prop(scene.mixamo, "apply_scale")
@@ -460,6 +458,9 @@ class MixamoconvPanel(bpy.types.Panel):
                 row = col.row()
                 row.prop(scene.mixamo, "knee_bones")
                 row.enabled = not scene.mixamo.b_remove_namespace and not scene.mixamo.b_unreal_bones
+
+                row = box.row()
+                row.prop(scene.mixamo, "foot_bone_workaround")
 
         # input and output paths for batch conversion
         box = layout.box()

--- a/mixamoconv.py
+++ b/mixamoconv.py
@@ -208,7 +208,15 @@ def quaternion_cleanup(object, prevent_flips=True, prevent_inverts=True):
                 if change_amount > 1.0:
                     for j in range(4):
                         zipped[i][j].co.y *= -1.0
-            
+
+def apply_foot_bone_workaround(armature, bonenames=['RightToeBase', 'LeftToeBase']):
+    """workaround for the twisting of the foot bones in some skeletons"""
+    if bpy.context.scene.mixamo.b_unreal_bones:
+        bonenames = ["ball_r", "ball_l"]
+
+    bpy.ops.object.mode_set(mode='EDIT')
+    for name in bonenames:
+        armature.data.edit_bones[name].roll = pi
 
 class Status:
     def __init__(self, msg, status_type='default'):
@@ -218,7 +226,7 @@ class Status:
         return str(self.msg)
 
 def hip_to_root(armature, use_x=True, use_y=True, use_z=True, on_ground=True, use_rotation=True, scale=1.0, restoffset=(0, 0, 0),
-                hipname='', fixbind=True, apply_rotation=True, apply_scale=False, quaternion_clean_pre=True, quaternion_clean_post=True):
+                hipname='', fixbind=True, apply_rotation=True, apply_scale=False, quaternion_clean_pre=True, quaternion_clean_post=True, foot_bone_workaround=False):
     """function to bake hipmotion to RootMotion in MixamoRigs"""
 
     yield Status("starting hip_to_root")
@@ -253,6 +261,9 @@ def hip_to_root(armature, use_x=True, use_y=True, use_z=True, on_ground=True, us
     if quaternion_clean_pre:
         quaternion_cleanup(root)
         yield Status("quaternion clean pre")
+
+    if foot_bone_workaround:
+        apply_foot_bone_workaround(armature)
 
     # apply restoffset to restpose and correct animation
     apply_restoffset(root, hips, restoffset)
@@ -413,7 +424,7 @@ def hip_to_root(armature, use_x=True, use_y=True, use_z=True, on_ground=True, us
 
 def batch_hip_to_root(source_dir, dest_dir, use_x=True, use_y=True, use_z=True, on_ground=True, use_rotation=True, scale=1.0,
                       restoffset=(0, 0, 0), hipname='', fixbind=True, apply_rotation=True, apply_scale=False,
-                      b_remove_namespace=True, b_unreal_bones=False, add_leaf_bones=False, knee_offset=(0, 0, 0), ignore_leaf_bones=True, automatic_bone_orientation=True, quaternion_clean_pre=True, quaternion_clean_post=True):
+                      b_remove_namespace=True, b_unreal_bones=False, add_leaf_bones=False, knee_offset=(0, 0, 0), ignore_leaf_bones=True, automatic_bone_orientation=True, quaternion_clean_pre=True, quaternion_clean_post=True, foot_bone_workaround=False):
     """Batch Convert MixamoRigs"""
 
     bpy.context.scene.unit_settings.system = 'METRIC'
@@ -490,7 +501,7 @@ def batch_hip_to_root(source_dir, dest_dir, use_x=True, use_y=True, use_z=True, 
             try:
                 for step in hip_to_root(armature, use_x=use_x, use_y=use_y, use_z=use_z, on_ground=on_ground, use_rotation=use_rotation, scale=scale,
                             restoffset=restoffset, hipname=hipname, fixbind=fixbind, apply_rotation=apply_rotation,
-                            apply_scale=apply_scale, quaternion_clean_pre=quaternion_clean_pre, quaternion_clean_post=quaternion_clean_post):
+                            apply_scale=apply_scale, quaternion_clean_pre=quaternion_clean_pre, quaternion_clean_post=quaternion_clean_post, foot_bone_workaround=foot_bone_workaround):
                     #DEBUG log.error(str(step))
                     pass
             except Exception as e:


### PR DESCRIPTION
New boolean property, foot_bone_workaround, defaulting to False. If set, a 180 degrees roll is applied to the LeftToeBase and RightToeBase (or ball_l and ball_r if using ue4 bone names).

Workaround for https://github.com/enziop/mixamo_converter/issues/31

The issue can reproduced with Mixamo's Eve by J. Gonzales, which is affected by the twisting of the bones when playing animations, and these changes make it possible for me to use the affected meshes with this plugin.